### PR TITLE
Overhaul firewall rule set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,36 @@
 # Terraform - Digital Ocean Swarm mode firewall rules
 
-Terraform module to configure Docker Swarm mode firewall rules on DigitalOcean. Based on the [Docker documentation](https://docs.docker.com/engine/swarm/swarm-tutorial/#open-protocols-and-ports-between-the-hosts).
+Terraform module to configure Docker Swarm mode firewall rules on DigitalOcean. Based on the [Docker documentation](https://docs.docker.com/engine/swarm/swarm-tutorial/#open-protocols-and-ports-between-the-hosts). This module provides a basic set of rules for cluster communications.
 
 [![CircleCI](https://circleci.com/gh/thojkooi/terraform-digitalocean-docker-swarm-firewall/tree/master.svg?style=svg)](https://circleci.com/gh/thojkooi/terraform-digitalocean-docker-swarm-firewall/tree/master)
 
 ---
 
+## Requirements
+
+- Terraform
+- Digitalocean account / API token with write access
+
 ## Usage
 
 ```hcl
 
+provider "digitalocean" {
+}
+
 resource "digitalocean_tag" "cluster" {
     name = "swarm-mode-cluster"
 }
+
 resource "digitalocean_tag" "manager" {
     name = "manager"
 }
+
 resource "digitalocean_tag" "worker" {
     name = "worker"
 }
 
-module "swarm-cluster" {
+module "swarm-mode-cluster" {
     source            = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
     total_managers    = 3
     total_workers     = 5
@@ -32,39 +42,31 @@ module "swarm-cluster" {
     worker_tags       = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.worker.id}"]
 }
 
-module "swarm-firewall" {
-    source              = "github.com/thojkooi/terraform-digitalocean-swarm-firewall"
-    do_token            = "${var.do_token}"
-    prefix              = "my-project"
-    cluster_tags        = ["${digitalocean_tag.manager.id}", "${digitalocean_tag.worker.id}"]
-    cluster_droplet_ids = []
-    allowed_outbound_addresses = ["0.0.0.0/0"]
+module "swarm-mode-firewall" {
+    source  = "thojkooi/docker-swarm-firewall/digitalocean"
+    version = "1.0.0"
+
+    prefix                     = "my-project"
+    cluster_tags               = ["${digitalocean_tag.cluster.id}"]
 }
 ```
-
-
-## Requirements
-
-- Terraform
-- Digitalocean account / API token with write access
 
 ## Firewall rules
 
 The following rules will be created:
 
-### Inbound
+### Cluster communications
+
+The following inbound rules are applied to any droplet that matches the id in `cluster_droplet_ids` or has a tag listed in `cluster_tags`:
 
 Port       | Description                       | Source
 ---------- | --------------------------------- | -------
-`2377/TCP` | cluster management communications | Cluster
-`7946/TCP` | Container network discovery       | Cluster
-`7946/UDP` | Container network discovery       | Cluster
-`4789/UDP` | Container overlay network         | Cluster
-`22/TCP`   | SSH access.                       | Adresses or droplets listed in `ssh_access_from_adresses`, `ssh_access_tags` or `ssh_access_droplet_ids`
+`2377/TCP` | cluster management communications | `cluster_droplet_ids`, `cluster_tags`
+`7946/TCP` | Container network discovery       | `cluster_droplet_ids`, `cluster_tags`
+`7946/UDP` | Container network discovery       | `cluster_droplet_ids`, `cluster_tags`
+`4789/UDP` | Container overlay network         | `cluster_droplet_ids`, `cluster_tags`
 
-### Outbound
+Please note that previous versions of this module also added rules for SSH access and various outbound rules. These have been removed from this module. Simliar functionality is provided by the following modules:
 
-Port    | Descripton                         | Destination
-------- | ---------------------------------- | -----------
-All/tcp | Traffic to any node in the cluster | Cluster
-All/udp | Traffic to any node in the cluster | Cluster
+- [DigitalOcean firewall rules set](https://github.com/thojkooi/terraform-digitalocean-firewall-rules), provides SSH inbound/outbound and various outbound rules.
+- [DigitalOcean Remote Docker API access](https://github.com/thojkooi/terraform-digitalocean-firewall-docker-api).

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -20,10 +20,11 @@ resource "digitalocean_tag" "worker" {
   name = "worker"
 }
 
-module "swarm-cluster" {
-  source           = "github.com/thojkooi/terraform-digitalocean-docker-swarm-mode"
-  total_managers   = 0
-  total_workers    = 0
+module "swarm-mode-cluster" {
+  source           = "thojkooi/docker-swarm-mode/digitalocean"
+  version          = "0.1.1"
+  total_managers   = 2
+  total_workers    = 2
   domain           = "do.example.com"
   do_token         = "${var.do_token}"
   manager_ssh_keys = "${var.ssh_keys}"
@@ -32,10 +33,20 @@ module "swarm-cluster" {
   worker_tags      = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.worker.id}"]
 }
 
-module "swarm-firewall" {
+# This module provides SSH access
+module "basic-fw-rules" {
+  source  = "thojkooi/firewall-rules/digitalocean"
+  version = "1.0.0"
+
+  prefix = "do-example-com"
+  tags   = ["${digitalocean_tag.cluster.id}"]
+}
+
+# Create the internal cluster firewall rules
+module "swarm-mode-firewall" {
   source              = "../"
   do_token            = "${var.do_token}"
-  prefix              = "production"
+  prefix              = "do-example-com"
   cluster_tags        = ["${digitalocean_tag.manager.id}", "${digitalocean_tag.worker.id}"]
   cluster_droplet_ids = []
 }

--- a/main.tf
+++ b/main.tf
@@ -1,37 +1,37 @@
-provider "digitalocean" {
-  version = "~> 0.1"
-  token   = "${var.do_token}"
-}
-
-resource "digitalocean_firewall" "swarm-mode-outbound-fw" {
-  name        = "${var.prefix}-swarm-mode-outbound-fw"
+resource "digitalocean_firewall" "swarm-mode-internal-fw" {
+  name        = "${var.prefix}-swarm-mode-internal-fw"
   droplet_ids = ["${var.cluster_droplet_ids}"]
   tags        = ["${var.cluster_tags}"]
 
   outbound_rule = [
     {
-      protocol                       = "udp"
-      port_range                     = "all"
-      destination_addresses          = ["${var.allowed_outbound_addresses}"]
-      destination_tags               = ["${var.allowed_outbound_droplet_tags}", "${var.cluster_droplet_ids}"]
-      destination_droplet_ids        = ["${var.allowed_outbound_droplet_ids}", "${var.cluster_droplet_ids}"]
-      destination_load_balancer_uids = ["${var.allowed_outbound_load_balancer_uids}"]
+      protocol                = "tcp"
+      port_range              = "2377"
+      destination_tags        = ["${var.cluster_tags}"]
+      destination_droplet_ids = ["${var.cluster_droplet_ids}"]
     },
     {
-      protocol                       = "tcp"
-      port_range                     = "all"
-      destination_addresses          = ["${var.allowed_outbound_addresses}"]
-      destination_tags               = ["${var.allowed_outbound_droplet_tags}", "${var.cluster_droplet_ids}"]
-      destination_droplet_ids        = ["${var.allowed_outbound_droplet_ids}", "${var.cluster_droplet_ids}"]
-      destination_load_balancer_uids = ["${var.allowed_outbound_load_balancer_uids}"]
+      # for container network discovery
+      protocol                = "tcp"
+      port_range              = "7946"
+      destination_tags        = ["${var.cluster_tags}"]
+      destination_droplet_ids = ["${var.cluster_droplet_ids}"]
+    },
+    {
+      # UDP for the container overlay network.
+      protocol                = "udp"
+      port_range              = "4789"
+      destination_tags        = ["${var.cluster_tags}"]
+      destination_droplet_ids = ["${var.cluster_droplet_ids}"]
+    },
+    {
+      # for container network discovery.
+      protocol                = "udp"
+      port_range              = "7946"
+      destination_tags        = ["${var.cluster_tags}"]
+      destination_droplet_ids = ["${var.cluster_droplet_ids}"]
     },
   ]
-}
-
-resource "digitalocean_firewall" "swarm-mode-internal-fw" {
-  name        = "${var.prefix}-swarm-mode-internal-fw"
-  droplet_ids = ["${var.cluster_droplet_ids}"]
-  tags        = ["${var.cluster_tags}"]
 
   inbound_rule = [
     {
@@ -39,7 +39,6 @@ resource "digitalocean_firewall" "swarm-mode-internal-fw" {
       port_range         = "2377"
       source_tags        = ["${var.cluster_tags}"]
       source_droplet_ids = ["${var.cluster_droplet_ids}"]
-      source_addresses   = []
     },
     {
       # for container network discovery
@@ -47,7 +46,6 @@ resource "digitalocean_firewall" "swarm-mode-internal-fw" {
       port_range         = "7946"
       source_tags        = ["${var.cluster_tags}"]
       source_droplet_ids = ["${var.cluster_droplet_ids}"]
-      source_addresses   = []
     },
     {
       # UDP for the container overlay network.
@@ -55,7 +53,6 @@ resource "digitalocean_firewall" "swarm-mode-internal-fw" {
       port_range         = "4789"
       source_tags        = ["${var.cluster_tags}"]
       source_droplet_ids = ["${var.cluster_droplet_ids}"]
-      source_addresses   = []
     },
     {
       # for container network discovery.
@@ -63,23 +60,6 @@ resource "digitalocean_firewall" "swarm-mode-internal-fw" {
       port_range         = "7946"
       source_tags        = ["${var.cluster_tags}"]
       source_droplet_ids = ["${var.cluster_droplet_ids}"]
-      source_addresses   = []
-    },
-  ]
-}
-
-resource "digitalocean_firewall" "swarm-cluster-ssh-access" {
-  name        = "${var.prefix}-swarm-ssh-access-fw"
-  droplet_ids = ["${var.cluster_droplet_ids}"]
-  tags        = ["${var.cluster_tags}"]
-
-  inbound_rule = [
-    {
-      protocol           = "tcp"
-      port_range         = "22"
-      source_tags        = ["${var.ssh_access_tags}"]
-      source_droplet_ids = ["${var.ssh_access_droplet_ids}"]
-      source_addresses   = ["${var.ssh_access_from_adresses}"]
     },
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "do_token" {
-  description = "DigitalOcean access token with read/write permissions"
-}
-
 variable "cluster_droplet_ids" {
   description = "List of droplet ids"
   type        = "list"
@@ -14,46 +10,4 @@ variable "cluster_tags" {
 
 variable "prefix" {
   description = "Prefix used for the name of the firewall rules"
-}
-
-variable "ssh_access_tags" {
-  default     = []
-  type        = "list"
-  description = "List of droplet tags from which SSH is allowed to any node in cluster"
-}
-
-variable "ssh_access_droplet_ids" {
-  default     = []
-  type        = "list"
-  description = "List of droplet ids from which SSH is allowed to any node in cluster"
-}
-
-variable "ssh_access_from_adresses" {
-  default     = ["0.0.0.0/0", "::/0"]
-  type        = "list"
-  description = "An array of strings containing the IPv4 addresses, IPv6 addresses, IPv4 CIDRs, and/or IPv6 CIDRs from which the inbound traffic will be accepted."
-}
-
-variable "allowed_outbound_addresses" {
-  default     = ["0.0.0.0/0", "::/0"]
-  type        = "list"
-  description = "An array of strings containing the IPv4 addresses, IPv6 addresses, IPv4 CIDRs, and/or IPv6 CIDRs to which outbound traffic will be allowed."
-}
-
-variable "allowed_outbound_droplet_ids" {
-  default     = []
-  type        = "list"
-  description = "An array of droplet ids to which outbound traffic will be allowed."
-}
-
-variable "allowed_outbound_droplet_tags" {
-  default     = []
-  type        = "list"
-  description = "An array of tags of droplets to which outbound traffic will be allowed."
-}
-
-variable "allowed_outbound_load_balancer_uids" {
-  default     = []
-  type        = "list"
-  description = "An array containing the IDs of the Load Balancers to which outbound traffic will be allowed."
 }


### PR DESCRIPTION
- Remove ssh access rules, should now use [thojkooi/firewall-rules/digitalocean](https://github.com/thojkooi/terraform-digitalocean-firewall-rules) or alternative solutions instead.
- Removed outbound rules to all ports. A generic set of rules is provided by thojkooi/firewall-rules/digitalocean for downloading packages, images, DNS lookups etc that can be used instead. Any additional outbound connections should be specifically allowed by creating a firewall rule for it.
- Remove do_token variable and specifying the digitalocean provider in this module. Instead uses the provider provided by the root or passed along to this module. See https://www.terraform.io/docs/modules/usage.html#providers-within-modules for more information.
- Add outbound rules for swarm mode cluster ports. This was previously covered by the allow_outbound rules that are now removed.

The intent of this overhaul is to simplify this module and provide only the rules specific for internal cluster access. 
